### PR TITLE
add better compatibility with other mods

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -943,7 +943,7 @@
   <!-- The facebook_pixel_event_params_FAE is retrieved from the request->post -->
   <file path="catalog/controller/common/footer.php">
     <operation>
-      <search><![CDATA[public function index()]]></search>
+      <search><![CDATA[public function index(]]></search>
       <add position="after"><![CDATA[
         $data['facebook_page_id_FAE'] =
           $this->config->get(FacebookCommonUtils::FACEBOOK_PAGE_ID);


### PR DESCRIPTION
other mods can add custom parameters, changing 
`public function index()`
to something like
`public function index($param1, $param2, ...)`

so the search string without the closing bracket is more universal